### PR TITLE
return resource tenant if cant get tenant list.

### DIFF
--- a/lib/pec/compute/tenant.rb
+++ b/lib/pec/compute/tenant.rb
@@ -4,7 +4,11 @@ module Pec
       extend Query
       class << self
         def get_name(id)
-          list.find {|p| p["id"] == id }["name"]
+          begin
+            list.find {|p| p["id"] == id }["name"]
+          rescue
+            Pec::Resource.get_tenant
+          end
         end
       end
     end

--- a/lib/pec/resource.rb
+++ b/lib/pec/resource.rb
@@ -17,6 +17,10 @@ module Pec
       def set_tenant(tenant)
         @@_tenant = tenant
       end
+
+      def get_tenant
+        @@_tenant
+      end
     end
   end
 end


### PR DESCRIPTION
`pec status`を実行時、instance の tenant 名を取得しようとした時に、下記のようなレスポンスが返ってきて tenant list が取得出来ないため list が例外を出すので、その場合は resource クラスの tenant 名を返すようにしてみました。

```
Expected([200, 204]) <=> Actual(300 Multiple Choices)
excon.error.response
  :body          => "{\"choices\": [{\"status\": \"CURRENT\", \"media-types\": [{\"base\": \"application/xml\", \"type\": \"application/vnd.openstack.compute+xml;version=2\"}, {\"base\": \"application/json\",
 \"type\": \"application/vnd.openstack.compute+json;version=2\"}], \"id\": \"v2.0\", \"links\": [{\"href\": \"http://api.XXXX.XXX:8774/v2/v2.0/tenants\", \"rel\": \"self\"}]}]}"
  :headers       => {
    "Content-Length" => "338"
    "Content-Type"   => "application/json"
    "Date"           => "Wed, 15 Jul 2015 06:22:20 GMT"
  }
---- snip ---
```
