### PR TITLE
add default config parameter

### DIFF
--- a/lib/pec/configure.rb
+++ b/lib/pec/configure.rb
@@ -12,7 +12,17 @@ module Pec
         hash = YAML.load_file(file_name).to_hash
       end
 
+      config_default = nil
       hash.each do |config|
+        if not config_default.nil?
+          config[1] = config_default.update(config[1])
+        else
+          if config[0] == '_DEFAULT_'
+            config_default = config[1]
+            next
+          end
+        end
+
         host = Pec::Configure::Host.new(config)
         @configure << host if host
       end

--- a/lib/pec/configure.rb
+++ b/lib/pec/configure.rb
@@ -12,16 +12,13 @@ module Pec
         hash = YAML.load_file(file_name).to_hash
       end
 
-      config_default = nil
+      config_default = {}
       hash.each do |config|
-        if not config_default.nil?
-          config[1] = config_default.update(config[1])
-        else
-          if config[0] == '_DEFAULT_'
-            config_default = config[1]
-            next
-          end
+        if config[0] =~ /^_DEFAULT_/
+          config_default = config_default.update(config[1])
+          next
         end
+        config[1] = config_default.update(config[1])
 
         host = Pec::Configure::Host.new(config)
         @configure << host if host


### PR DESCRIPTION
この PR は Pec.yaml の定義で冗長な部分がある場合に default parameter を設定出来るようにします。
下記のような設定を Pec.yaml に記述することで、それ以下の設定に適用できます。

```
_DEFAULT_:
  tenant: tenant1
  image: CentOS-7-x86_64
  flavor: m1.medium
  networks:
    eth0:
      bootproto: static
      ip_address: 192.168.0.0/24
      gateway: 192.168.0.1
    eth1:
      bootproto: static
      ip_address: 192.168.1.0/24
  security_group:
    - default
  templates:
    - default.yaml
```
