### PR TITLE
override fqdn. if not defined in yaml.

### DIFF
--- a/lib/pec/configure.rb
+++ b/lib/pec/configure.rb
@@ -20,6 +20,9 @@ module Pec
         end
         config[1] = config_default.update(config[1])
 
+        config[1]['user_data'] ||= {}
+        config[1]['user_data']['fqdn'] ||= config[0]
+
         host = Pec::Configure::Host.new(config)
         @configure << host if host
       end


### PR DESCRIPTION
user_data の fqdn 設定省略した場合、cloud-init 任せにすると fqdn 設定が ${server_name}.novalocal になるので、${server_name} で fqdn を設定します。

例えば、下記のような設定にした場合、
fqdn が `foo.example.com.novalocal` にならず `foo.example.com` に設定されます。

```
foo.example.com:
  user_data: {}
```
