### PR TITLE
Revert add default config parameter. And add skip keyword

### DIFF
--- a/lib/pec/configure.rb
+++ b/lib/pec/configure.rb
@@ -12,14 +12,7 @@ module Pec
         hash = YAML.load_file(file_name).to_hash
       end
 
-      config_default = {}
       hash.each do |config|
-        if config[0] =~ /^_DEFAULT_/
-          config_default = config_default.update(config[1])
-          next
-        end
-        config[1] = config_default.update(config[1])
-
         config[1]['user_data'] ||= {}
         config[1]['user_data']['fqdn'] ||= config[0]
 

--- a/lib/pec/configure.rb
+++ b/lib/pec/configure.rb
@@ -13,6 +13,8 @@ module Pec
       end
 
       hash.each do |config|
+        next if config[0] =~ /^_.+_$/
+
         config[1]['user_data'] ||= {}
         config[1]['user_data']['fqdn'] ||= config[0]
 


### PR DESCRIPTION
@lamanotrama に yaml のマージ機能で良いんじゃない？との指摘を頂いたので、サーバ設定のマージ機能は revert します。
server_name を特定のキーワード `^_.+_$` で設定したものについては、サーバ設定としては認識しないように skip します。このサーバ設定は default 設定として利用できます。

```
'_default_': &default
  tenant: tenant001
  image: CentOS-6-x86_64
  flavor: m1.medium
  security_group:
    - default
  templates:
    - default.yaml

'_foo_': &foo
  <<: *default
  flavor: m1.large
  security_group:
    - default
    - foo

'foo001.example.com':
  <<: *foo

'foo002.example.com':
  <<: *foo

'_bar_': &bar
  <<: *default
  security_group:
    - default
    - bar

'bar001.example.com':
  <<: *bar
```